### PR TITLE
This fixes a bug in edf7a12 in that it assumed a particular working

### DIFF
--- a/server/mlabns/util/util.py
+++ b/server/mlabns/util/util.py
@@ -1,12 +1,15 @@
 import json
+import os
 
 import jinja2
 
 from mlabns.util import message
 
 def _get_jinja_environment():
+    current_dir = os.path.dirname(__file__)
+    templates_dir = os.path.join(current_dir, '../templates')
     return jinja2.Environment(
-        loader=jinja2.FileSystemLoader('mlabns/templates'),
+        loader=jinja2.FileSystemLoader(templates_dir),
         extensions=['jinja2.ext.autoescape'], autoescape=True)
 
 def _get_jinja_template(template_filename):


### PR DESCRIPTION
directory when the code is executed. This resulted in the test suite
breaking if the user executed it from outside the server dir.

This fixes jinja2 so that it finds the template directory relative to
where the executing script is stored in the source tree. This is
consistent with the GAE documentation: https://cloud.google.com/appengine/docs/python/gettingstartedpython27/templates
