### PR TITLE
Rewrite of test_lookup_query and slight refactoring of LookupQuery.

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -351,10 +351,10 @@ class LookupHandler(webapp.RequestHandler):
             '%s,'
             '%s,%s,%s,%s,%s,%s,%s',
             # Info about the user:
-            query.user_defined_ip,
-            query.user_defined_af,
-            query.gae_ip,
-            query.gae_af,
+            query._user_defined_ip,
+            query._user_defined_af,
+            query._gae_ip,
+            query._gae_af,
             query.ip_address,
             query.address_family,
             user_agent,
@@ -363,7 +363,7 @@ class LookupHandler(webapp.RequestHandler):
             query.tool_id,
             query.policy,
             query.response_format,
-            query.geolocation_type,
+            query._geolocation_type,
             query.metro,
             str(time.time()),
             # Calculated information about the lookup:

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -352,7 +352,7 @@ class LookupHandler(webapp.RequestHandler):
             '%s,%s,%s,%s,%s,%s,%s',
             # Info about the user:
             query._user_defined_ip,
-            query._user_defined_af,
+            query.user_defined_af,
             query._gae_ip,
             query._gae_af,
             query.ip_address,

--- a/server/mlabns/tests/test_lookup_query.py
+++ b/server/mlabns/tests/test_lookup_query.py
@@ -168,8 +168,8 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.mock_query_params[message.ADDRESS_FAMILY] = 'invalid_af'
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.mock_request)
-        self.assertEqual(user_defined_ipv4, query._user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query._user_defined_af)
+        self.assertEqual(user_defined_ipv4, query.ip_address)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
 
     def testInitializeIgnoresUserDefinedAfIfItDoesNotMatchUserDefinedIpv4(
             self):
@@ -179,8 +179,8 @@ class LookupQueryTestCase(unittest2.TestCase):
             message.ADDRESS_FAMILY_IPv6)
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.mock_request)
-        self.assertEqual(user_defined_ipv4, query._user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query._user_defined_af)
+        self.assertEqual(user_defined_ipv4, query.ip_address)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
 
     def testInitializeIgnoresUserDefinedAfIfItDoesNotMatchUserDefinedIpv6(
             self):
@@ -190,8 +190,8 @@ class LookupQueryTestCase(unittest2.TestCase):
             message.ADDRESS_FAMILY_IPv4)
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.mock_request)
-        self.assertEqual(user_defined_ipv6, query._user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query._user_defined_af)
+        self.assertEqual(user_defined_ipv6, query.ip_address)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.user_defined_af)
 
     def testInitializeAcceptsValidUserDefinedCityAndLatLon(self):
         user_defined_city = 'user_defined_city'
@@ -315,6 +315,7 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertEqual(maxmind_longitude, query.longitude)
         self.assertIsNone(query.city)
         self.assertEqual(maxmind_country, query.country)
+        self.assertEqual(user_defined_country, query.user_defined_country)
 
     def testInitializeAcceptsUserDefinedLatLonAndCountry(self):
         user_defined_latitude = 99.0
@@ -332,6 +333,7 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertEqual(user_defined_longitude, query.longitude)
         self.assertIsNone(query.city)
         self.assertEqual(user_defined_country, query.country)
+        self.assertEqual(user_defined_country, query.user_defined_country)
 
     def testInitializeAcceptsGeoPolicy(self):
         self.mock_query_params[message.POLICY] = message.POLICY_GEO
@@ -351,6 +353,7 @@ class LookupQueryTestCase(unittest2.TestCase):
 
         self.assertEqual(message.POLICY_COUNTRY, query.policy)
         self.assertEqual(user_defined_country, query.country)
+        self.assertEqual(user_defined_country, query.user_defined_country)
 
     def testInitializeUsesMaxmindWhenUserDefinedIpv4Exists(self):
         user_defined_ip = '5.6.7.8'

--- a/server/mlabns/tests/test_lookup_query.py
+++ b/server/mlabns/tests/test_lookup_query.py
@@ -1,26 +1,68 @@
 import collections
+
 import mock
 import unittest2
 
 from mlabns.util import constants
 from mlabns.util import lookup_query
+from mlabns.util import maxmind
 from mlabns.util import message
 
 
 class LookupQueryTestCase(unittest2.TestCase):
 
+    def mock_get(self, arg, default_value):
+        """Mock method to replace the GAE get() API for web requests."""
+        if arg in self.mock_query_params:
+            return self.mock_query_params[arg]
+        else:
+            return default_value
+
     def setUp(self):
-        self.mock_query_params = collections.defaultdict(lambda: None)
+        # Mock out calls to Maxmind
+        maxmind_get_ip_geolocation_patch = mock.patch.object(
+            maxmind, 'get_ip_geolocation', autospec=True)
+        self.addCleanup(maxmind_get_ip_geolocation_patch.stop)
+        maxmind_get_ip_geolocation_patch.start()
+
+        maxmind_get_city_geolocation_patch = mock.patch.object(
+            maxmind, 'get_city_geolocation', autospec=True)
+        self.addCleanup(maxmind_get_city_geolocation_patch.stop)
+        maxmind_get_city_geolocation_patch.start()
+
+        maxmind_get_country_geolocation_patch = mock.patch.object(
+            maxmind, 'get_country_geolocation', autospec=True)
+        self.addCleanup(maxmind_get_country_geolocation_patch.stop)
+        maxmind_get_country_geolocation_patch.start()
+
+        # Create a defaul mock request with no explicit parameters except
+        # the tool ID.
+        self.mock_tool_id = 'ndt'
+        self.mock_request_ip = '1.2.3.4'
+        self.mock_request_af = message.ADDRESS_FAMILY_IPv4
+        self.mock_query_params = {}
         self.mock_request = mock.Mock()
-        self.mock_request.get.side_effect = (
-            lambda arg, default_value: self.mock_query_params[arg])
+        self.mock_request.path = '/' + self.mock_tool_id
+        self.mock_request.remote_addr = self.mock_request_ip
+        self.mock_request.get.side_effect = self.mock_get
+
+        # Set mock GAE geolocation headers
+        self.mock_gae_latitude = 123.4
+        self.mock_gae_longitude = 32.1
+        self.mock_gae_city = 'gae_city'
+        self.mock_gae_country = 'gae_country'
+        self.mock_request.headers = {
+            message.HEADER_LAT_LONG: '%.1f,%.1f' % (
+                self.mock_gae_latitude, self.mock_gae_longitude),
+            message.HEADER_CITY: self.mock_gae_city,
+            message.HEADER_COUNTRY: self.mock_gae_country,
+            }
 
     def testDefaultConstructor(self):
         query = lookup_query.LookupQuery()
         self.assertIsNone(query.tool_id)
         self.assertIsNone(query.policy)
         self.assertIsNone(query.metro)
-        self.assertIsNone(query.geolocation_type)
         self.assertIsNone(query.response_format)
         self.assertIsNone(query.ip_address)
         self.assertIsNone(query.address_family)
@@ -29,562 +71,385 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertIsNone(query.latitude)
         self.assertIsNone(query.longitude)
         self.assertIsNone(query.distance)
-        self.assertIsNone(query.gae_ip)
-        self.assertIsNone(query.gae_af)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertIsNone(query.user_defined_af)
-        self.assertIsNone(query.gae_city)
-        self.assertIsNone(query.gae_country)
-        self.assertIsNone(query.gae_latitude)
-        self.assertIsNone(query.gae_longitude)
-        self.assertIsNone(query.maxmind_city)
-        self.assertIsNone(query.maxmind_country)
-        self.assertIsNone(query.maxmind_latitude)
-        self.assertIsNone(query.maxmind_longitude)
-        self.assertIsNone(query.user_defined_city)
-        self.assertIsNone(query.user_defined_country)
-        self.assertIsNone(query.user_defined_latitude)
-        self.assertIsNone(query.user_defined_longitude)
 
-    def testSetResponseFormatNoneFormat(self):
-        query = lookup_query.LookupQuery()
-        query.set_response_format(self.mock_request)
-        self.assertEqual(query.response_format,
-                         message.DEFAULT_RESPONSE_FORMAT)
-
-    def testSetResponseFormatNonValidFormat(self):
-        self.mock_query_params[message.RESPONSE_FORMAT] = 'non_valid_format'
-        query = lookup_query.LookupQuery()
-        query.set_response_format(self.mock_request)
-        self.assertEqual(query.response_format,
-                         message.DEFAULT_RESPONSE_FORMAT)
-
-    def testSetResponseFormatValidFormat(self):
-        self.mock_query_params[message.RESPONSE_FORMAT] = message.FORMAT_HTML
-        query = lookup_query.LookupQuery()
-        query.set_response_format(self.mock_request)
-        self.assertEqual(query.response_format, message.FORMAT_HTML)
-
-    def testSetUserDefinedIpAndAfNoIpNoAf(self):
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertIsNone(query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfNoIpNonValidAf(self):
-        self.mock_query_params[message.ADDRESS_FAMILY] = 'non_valid_af'
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertIsNone(query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfNoIpValidAf4(self):
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv4)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfNoIpValidAf6(self):
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv6)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-
-    def testSetUserDefinedIpAndAfNonValidIpNoAf(self):
-        self.mock_query_params[message.REMOTE_ADDRESS] = 'non_valid_ip'
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertIsNone(query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfNonValidIpNonValidAf(self):
-        self.mock_query_params[message.REMOTE_ADDRESS] = 'non_valid_ip'
-        self.mock_query_params[message.ADDRESS_FAMILY] = 'non_valid_af'
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertIsNone(query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfNonValidIpValidAf4(self):
-        self.mock_query_params[message.REMOTE_ADDRESS] = 'non_valid_ip'
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv4)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfNonValidIpValidAf6(self):
-        self.mock_query_params[message.REMOTE_ADDRESS] = 'non_valid_ip'
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv6)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertIsNone(query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv4NoAf(self):
-        valid_ipv4 = '1.2.3.4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv4
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv4, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv6NoAf(self):
-        valid_ipv6 = '1:2:3::4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv6
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv6, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6,
-                         query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv4NonvalidAf(self):
-        valid_ipv4 = '1.2.3.4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv4
-        self.mock_query_params[message.ADDRESS_FAMILY] = 'non_valid_af'
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv4, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv6NonvalidAf(self):
-        valid_ipv6 = '1:2:3::4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv6
-        self.mock_query_params[message.ADDRESS_FAMILY] = 'non_valid_af'
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv6, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv4ValidAf4(self):
-        valid_ipv4 = '1.2.3.4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv4
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv4)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv4, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv4ValidAf6(self):
-        valid_ipv4 = '1.2.3.4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv4
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv6)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv4, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv6ValidAf4(self):
-        valid_ipv6 = '1:2:3::4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv6
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv4)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv6, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.user_defined_af)
-
-    def testSetUserDefinedIpAndAfValidIpv6ValidAf6(self):
-        valid_ipv6 = '1:2:3::4'
-        self.mock_query_params[message.REMOTE_ADDRESS] = valid_ipv6
-        self.mock_query_params[message.ADDRESS_FAMILY] = (
-            message.ADDRESS_FAMILY_IPv6)
-        query = lookup_query.LookupQuery()
-        query.set_user_defined_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv6, query.user_defined_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.user_defined_af)
-
-    def testSetGaeIpAndAfNoIp(self):
-        self.mock_request.remote_addr = None
-        query = lookup_query.LookupQuery()
-        query.set_gae_ip_and_af(self.mock_request)
-        self.assertIsNone(query.gae_ip)
-        self.assertIsNone(query.gae_af)
-
-    def testSetGaeIpAndAfNonValidIp(self):
-        self.mock_request.get.remote_addr = 'non_valid_ip'
-        query = lookup_query.LookupQuery()
-        query.set_gae_ip_and_af(self.mock_request)
-        self.assertIsNone(query.gae_ip)
-        self.assertIsNone(query.gae_af)
-
-    def testSetGaeIpAndAfValidIpv4(self):
-        valid_ipv4 = '1.2.3.4'
-        self.mock_request.remote_addr = valid_ipv4
-        query = lookup_query.LookupQuery()
-        query.set_gae_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv4, query.gae_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.gae_af)
-
-    def testSetGaeIpAndAfValidIpv6(self):
-        valid_ipv6 = '1:2:3::4'
-        self.mock_request.remote_addr = valid_ipv6
-        query = lookup_query.LookupQuery()
-        query.set_gae_ip_and_af(self.mock_request)
-        self.assertEqual(valid_ipv6, query.gae_ip)
-        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.gae_af)
-
-    def testSetIpAddressAndAddressFamilyUserDefined(self):
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def __init__(self):
-                self.user_defined_ip = 'user_defined_ip'
-                self.user_defined_af = 'user_defined_af'
-                self.gae_ip = 'gae_ip'
-                self.gae_af = 'gae_af'
-            def set_user_defined_ip_and_af(self, unused_arg): pass
-            def set_gae_ip_and_af(self, unused_arg): pass
-
-        query = LookupQueryMockup()
-        query.set_ip_address_and_address_family(self.mock_request)
-        self.assertEqual('user_defined_ip', query.ip_address)
-        self.assertEqual('user_defined_af', query.address_family)
-
-    def testSetIpAddressAndAddressFamilyGAE(self):
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def __init__(self):
-                self.user_defined_ip = None
-                self.user_defined_af = None
-                self.gae_ip = 'gae_ip'
-                self.gae_af = 'gae_af'
-            def set_user_defined_ip_and_af(self, unused_arg): pass
-            def set_gae_ip_and_af(self, unused_arg): pass
-
-        query = LookupQueryMockup()
-        query.set_ip_address_and_address_family(self.mock_request)
-        self.assertEqual('gae_ip', query.ip_address)
-        self.assertEqual('gae_af', query.address_family)
-
-    def testSetIpAddressAndAddressFamilyMixed(self):
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def __init__(self):
-                self.user_defined_ip = 'user_defined_ip'
-                self.user_defined_af = None
-                self.gae_ip = 'gae_ip'
-                self.gae_af = None
-                self.address_family = None
-            def set_user_defined_ip_and_af(self, unused_arg): pass
-            def set_gae_ip_and_af(self, unused_arg): pass
-
-        query = LookupQueryMockup()
-        query.set_ip_address_and_address_family(self.mock_request)
-        self.assertEqual('user_defined_ip', query.ip_address)
-        self.assertIsNone(query.address_family)
-
-    def testSetGeoLocationUsedDefinedValidLatLong(self):
-        lat = 0.0
-        lon = 4.3
-        city = 'valid_city'
-        country = None
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def set_appengine_geolocation(self, unused_arg): pass
-
-        self.mock_query_params[message.LATITUDE] = lat
-        self.mock_query_params[message.LONGITUDE] = lon
-        self.mock_query_params[message.CITY] = city
-        self.mock_query_params[message.COUNTRY] = country
-
-        query = LookupQueryMockup()
-        query.set_geolocation(self.mock_request)
-
-        self.assertEqual(constants.GEOLOCATION_USER_DEFINED,
-                         query.geolocation_type)
-        self.assertEqual(lat, query.user_defined_latitude)
-        self.assertEqual(lon, query.user_defined_longitude)
-        self.assertEqual(city, query.user_defined_city)
-        self.assertEqual(country, query.user_defined_country)
-
-        self.assertEqual(query.user_defined_latitude, query.latitude)
-        self.assertEqual(query.user_defined_longitude, query.longitude)
-        self.assertEqual(query.user_defined_city, query.city)
-        self.assertEqual(query.user_defined_country, query.country)
-
-    def testSetGeoLocationUsedDefinedNoValidLatLong(self):
-        lat = 'non_valid_lat'
-        lon = 'non_valid_lon'
-        city = 'valid_city'
-        country = None
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def set_appengine_geolocation(self, unused_arg): pass
-
-        self.mock_query_params[message.LATITUDE] = lat
-        self.mock_query_params[message.LONGITUDE] = lon
-        self.mock_query_params[message.CITY] = city
-        self.mock_query_params[message.COUNTRY] = country
-
-        query = LookupQueryMockup()
-        query.set_geolocation(self.mock_request)
-
-        self.assertEqual(constants.GEOLOCATION_USER_DEFINED,
-                         query.geolocation_type)
-        self.assertIsNone(query.user_defined_latitude)
-        self.assertIsNone(query.user_defined_longitude)
-        self.assertEqual(city, query.user_defined_city)
-        self.assertEqual(country, query.user_defined_country)
-
-        self.assertEqual(query.user_defined_latitude, query.latitude)
-        self.assertEqual(query.user_defined_longitude, query.longitude)
-        self.assertEqual(query.user_defined_city, query.city)
-        self.assertEqual(query.user_defined_country, query.country)
-
-    def testSetGeoLocationUsedDefinedIpOrCountryAndMaxmind(self):
-        lat = 'maxmind_latitude'
-        lon = 'maxmind_logitude'
-        city = None
-        country = 'maxmind_country'
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def set_appengine_geolocation(self, unused_arg): pass
-            def set_maxmind_geolocation(
-                self, unused_arg1, unused_arg2, unused_arg3):
-                self.maxmind_latitude = lat
-                self.maxmind_longitude = lon
-                self.maxmind_city = city
-                self.maxmind_country = country
-
-        query = LookupQueryMockup()
-        query.user_defined_ip = 'valid_ip'
-        query.set_geolocation(self.mock_request)
-        self.assertEqual(constants.GEOLOCATION_MAXMIND, query.geolocation_type)
-        self.assertEqual(lat, query.maxmind_latitude)
-        self.assertEqual(lon, query.maxmind_longitude)
-        self.assertEqual(city, query.maxmind_city)
-        self.assertEqual(country, query.maxmind_country)
-
-        self.assertEqual(query.maxmind_latitude, query.latitude)
-        self.assertEqual(query.maxmind_longitude, query.longitude)
-        self.assertEqual(query.maxmind_city, query.city)
-        self.assertEqual(query.maxmind_country, query.country)
-
-        self.mock_query_params[message.COUNTRY] = 'valid_country'
-        query.set_geolocation(self.mock_request)
-        self.assertEqual(constants.GEOLOCATION_MAXMIND, query.geolocation_type)
-        self.assertEqual(lat, query.maxmind_latitude)
-        self.assertEqual(lon, query.maxmind_longitude)
-        self.assertEqual(city, query.maxmind_city)
-        self.assertEqual(country, query.maxmind_country)
-
-        self.assertEqual(query.maxmind_latitude, query.latitude)
-        self.assertEqual(query.maxmind_longitude, query.longitude)
-        self.assertEqual(query.maxmind_city, query.city)
-        self.assertEqual(query.maxmind_country, query.country)
-
-    def testSetGeoLocationGAELatLong(self):
-        lat = 'gae_latitude'
-        lon = 'gae_logitude'
-        city = None
-        country = 'gae_country'
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def set_appengine_geolocation(self, unused_arg):
-                self.gae_latitude = lat
-                self.gae_longitude = lon
-                self.gae_city = city
-                self.gae_country = country
-
-        query = LookupQueryMockup()
-        query.set_geolocation(self.mock_request)
-        self.assertEqual(constants.GEOLOCATION_APP_ENGINE,
-                         query.geolocation_type)
-        self.assertEqual(lat, query.gae_latitude)
-        self.assertEqual(lon, query.gae_longitude)
-        self.assertEqual(city, query.gae_city)
-        self.assertEqual(country, query.gae_country)
-
-        self.assertEqual(query.gae_latitude, query.latitude)
-        self.assertEqual(query.gae_longitude, query.longitude)
-        self.assertEqual(query.gae_city, query.city)
-        self.assertEqual(query.gae_country, query.country)
-
-    def testSetGeoLocationGAEIpOrCountryAndMaxmind(self):
-        lat = 'maxmind_latitude'
-        lon = 'maxmind_logitude'
-        city = None
-        country = 'maxmind_country'
-
-        class LookupQueryMockup(lookup_query.LookupQuery):
-            def set_appengine_geolocation(self, unused_arg): pass
-            def set_maxmind_geolocation(
-                self, unused_arg1, unused_arg2, unused_arg3):
-                self.maxmind_latitude = lat
-                self.maxmind_longitude = lon
-                self.maxmind_city = city
-                self.maxmind_country = country
-
-        query = LookupQueryMockup()
-        query.user_defined_ip = 'valid_ip'
-        query.set_geolocation(self.mock_request)
-        self.assertEqual(constants.GEOLOCATION_MAXMIND, query.geolocation_type)
-        self.assertEqual(lat, query.maxmind_latitude)
-        self.assertEqual(lon, query.maxmind_longitude)
-        self.assertEqual(city, query.maxmind_city)
-        self.assertEqual(country, query.maxmind_country)
-
-        self.assertEqual(query.maxmind_latitude, query.latitude)
-        self.assertEqual(query.maxmind_longitude, query.longitude)
-        self.assertEqual(query.maxmind_city, query.city)
-        self.assertEqual(query.maxmind_country, query.country)
-
-        query = LookupQueryMockup()
-        self.mock_query_params[message.COUNTRY] = 'valid_country'
-        query.set_geolocation(self.mock_request)
-        self.assertEqual(constants.GEOLOCATION_MAXMIND, query.geolocation_type)
-        self.assertEqual(lat, query.maxmind_latitude)
-        self.assertEqual(lon, query.maxmind_longitude)
-        self.assertEqual(city, query.maxmind_city)
-        self.assertEqual(country, query.maxmind_country)
-
-        self.assertEqual(query.maxmind_latitude, query.latitude)
-        self.assertEqual(query.maxmind_longitude, query.longitude)
-        self.assertEqual(query.maxmind_city, query.city)
-        self.assertEqual(query.maxmind_country, query.country)
-
-    def testSetMaxmindGeolocationNone(self):
-        query = lookup_query.LookupQuery()
-        query.set_maxmind_geolocation(None, None, None)
-        self.assertIsNone(query.maxmind_city)
-        self.assertIsNone(query.maxmind_country)
-        self.assertIsNone(query.maxmind_latitude)
-        self.assertIsNone(query.maxmind_longitude)
-
-    def testSetAppengineGeolocationValidLatLong(self):
-        valid_city = 'valid_city'
-        valid_latitude = 0.0
-        valid_longitude = 3.0
-        self.mock_request.headers = {
-            message.HEADER_CITY: valid_city,
-            message.HEADER_LAT_LONG: '0.0,3.0'
-            }
-        query = lookup_query.LookupQuery()
-        query.set_appengine_geolocation(self.mock_request)
-        self.assertEqual(valid_city, query.gae_city)
-        self.assertIsNone(query.gae_country)
-        self.assertEqual(valid_latitude, query.gae_latitude)
-        self.assertEqual(valid_longitude, query.gae_longitude)
-
-    def testSetPolicyUserDefinedGeoPolicyGeo(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_GEO
-        query = lookup_query.LookupQuery()
-        query.user_defined_ip = 'valid_ip'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_GEO, query.policy)
-
-        query = lookup_query.LookupQuery()
-        query.user_defined_latitude = 'valid_lat'
-        query.user_defined_longitude = 'valid_long'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_GEO, query.policy)
-
-    def testSetPolicyUserDefinedGeoPolicyNoGeo(self):
-        self.mock_query_params[message.POLICY] = 'no_geo_policy'
-        query = lookup_query.LookupQuery()
-        query.user_defined_ip = 'valid_ip'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_GEO, query.policy)
-
-        query = lookup_query.LookupQuery()
-        query.user_defined_latitude = 'valid_lat'
-        query.user_defined_longitude = 'valid_long'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_GEO, query.policy)
-
-    def testSetPolicyUserDefinedCountryPolicyCountry(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_COUNTRY
-        query = lookup_query.LookupQuery()
-        query.user_defined_country = 'valid_country'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_COUNTRY, query.policy)
-
-    def testSetPolicyUserDefinedCountryPolicyGeo(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_GEO
-        query = lookup_query.LookupQuery()
-        query.user_defined_country = 'valid_country'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_GEO, query.policy)
-
-    def testSetPolicyUserDefinedCountryPolicyNoGeoNoCountry(self):
-        self.mock_query_params[message.POLICY] = 'no_geo_no_country_policy'
-        query = lookup_query.LookupQuery()
-        query.user_defined_country = 'valid_country'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_GEO, query.policy)
-
-    def testSetPolicyUserDefinedMetroPolicyMetro(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_METRO
-        query = lookup_query.LookupQuery()
-        query.metro = 'valid_metro'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_METRO, query.policy)
-
-    def testSetPolicyUserDefinedMetroPolicyNoMetro(self):
-        self.mock_query_params[message.POLICY] = 'no_metro_policy'
-        query = lookup_query.LookupQuery()
-        query.metro = 'valid_metro'
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_METRO, query.policy)
-
-    def testSetPolicyGeoPolicyNoGeo(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_GEO
-        query = lookup_query.LookupQuery()
-        query.latitude = 'valid_lat'
-        query.longitude = None
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-
-    def testSetPolicyCountryPolicyNoUserDefinedCountry(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_COUNTRY
-        query = lookup_query.LookupQuery()
-        query.user_defined_country = None
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-
-    def testSetPolicyMetroPolicyNoMetro(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_METRO
-        query = lookup_query.LookupQuery()
-        query.metro = None
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-
-    def testSetPolicyPolicyRandom(self):
-        self.mock_query_params[message.POLICY] = message.POLICY_RANDOM
-        query = lookup_query.LookupQuery()
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-
-    def testSetPolicyNoPolicy(self):
-        query = lookup_query.LookupQuery()
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-
-    def testSetPolicyNonValidPolicy(self):
-        self.mock_query_params[message.POLICY] = 'non_valid_policy'
-        query = lookup_query.LookupQuery()
-        query.set_policy(self.mock_request)
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-
-    def testInitializeFromHttpRequest(self):
-        valid_metro = 'valid_metro'
-        valid_tool = 'valid_tool'
-        self.mock_query_params[message.METRO] = valid_metro
-        self.mock_request.path = valid_tool + '/xyz/'
-        self.mock_request.remote_addr = None
-        self.mock_request.headers = {}
+    def testInitializeWhenNoUserDefinedOptionsAreSpecified(self):
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.mock_request)
-        self.assertEqual(valid_tool, query.tool_id)
-        self.assertEqual(valid_metro, query.metro)
+        self.assertEqual(query.response_format,
+                         message.DEFAULT_RESPONSE_FORMAT)
+        self.assertEqual(self.mock_tool_id, query.tool_id)
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertIsNone(query.metro)
+        self.assertEqual(message.DEFAULT_RESPONSE_FORMAT, query.response_format)
+        self.assertEqual(self.mock_request_ip, query.ip_address)
+        self.assertEqual(self.mock_request_af, query.address_family)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertIsNone(query.distance)
+
+    def testInitializeParsesToolName(self):
+        self.mock_request.path = '/valid_tool_name'
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual('valid_tool_name', query.tool_id)
+
+    def testInitializeSetsDefaultResponseFormatWhenUserDefinedValueIsInvalid(
+            self):
+        self.mock_query_params[message.RESPONSE_FORMAT] = 'invalid_format'
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(query.response_format,
+                         message.DEFAULT_RESPONSE_FORMAT)
+
+    def testInitializeAcceptsValidUserDefinedFormat(self):
+        self.mock_query_params[message.RESPONSE_FORMAT] = message.FORMAT_HTML
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(query.response_format, message.FORMAT_HTML)
+
+    def testInitializeIgnoresInvalidUserDefinedAfOnly(self):
+        """An invalid user-defined AF should be ignored."""
+        self.mock_query_params[message.ADDRESS_FAMILY] = 'invalid_af'
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(self.mock_request_ip, query.ip_address)
+        self.assertEqual(self.mock_request_af, query.address_family)
+
+    def testInitializeIgnoresUserDefinedAfOnly(self):
+        """A user-defined AF should be ignored if user-defined IP is absent."""
+        self.mock_query_params[message.ADDRESS_FAMILY] = (
+            message.ADDRESS_FAMILY_IPv6)
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(self.mock_request_ip, query.ip_address)
+        self.assertEqual(self.mock_request_af, query.address_family)
+
+    def testInitializeIgnoresInvalidUserDefinedIpOnly(self):
+        """Ignore an invalid user-defined IP address."""
+        self.mock_query_params[message.REMOTE_ADDRESS] = 'invalid_ip'
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(self.mock_request_ip, query.ip_address)
+        self.assertEqual(self.mock_request_af, query.address_family)
+
+    def testInitializeIgnoresInvalidUserDefinedIpWithValidAf(self):
+        """Ignore an invalid user-defined IP even if AF is valid."""
+        self.mock_query_params[message.REMOTE_ADDRESS] = 'invalid_ip'
+        self.mock_query_params[message.ADDRESS_FAMILY] = (
+            message.ADDRESS_FAMILY_IPv4)
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(self.mock_request_ip, query.ip_address)
+        self.assertEqual(self.mock_request_af, query.address_family)
+
+    def testInitializeDeducesAfFromUserDefinedIpv4(self):
+        user_defined_ipv4 = '9.8.7.6'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ipv4
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(user_defined_ipv4, query.ip_address)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query.address_family)
+
+    def testInitializeDeducesAfFromUserDefinedIpv6(self):
+        user_defined_ipv6 = '1:2:3::4'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ipv6
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(user_defined_ipv6, query.ip_address)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query.address_family)
+
+    def testInitializeDeducesAfFromUserDefinedIpv4AndIgnoresInvalidAf(self):
+        user_defined_ipv4 = '9.8.7.6'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ipv4
+        self.mock_query_params[message.ADDRESS_FAMILY] = 'invalid_af'
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(user_defined_ipv4, query._user_defined_ip)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query._user_defined_af)
+
+    def testInitializeIgnoresUserDefinedAfIfItDoesNotMatchUserDefinedIpv4(
+            self):
+        user_defined_ipv4 = '9.8.7.6'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ipv4
+        self.mock_query_params[message.ADDRESS_FAMILY] = (
+            message.ADDRESS_FAMILY_IPv6)
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(user_defined_ipv4, query._user_defined_ip)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv4, query._user_defined_af)
+
+    def testInitializeIgnoresUserDefinedAfIfItDoesNotMatchUserDefinedIpv6(
+            self):
+        user_defined_ipv6 = '1:2:3::4'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ipv6
+        self.mock_query_params[message.ADDRESS_FAMILY] = (
+            message.ADDRESS_FAMILY_IPv4)
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(user_defined_ipv6, query._user_defined_ip)
+        self.assertEqual(message.ADDRESS_FAMILY_IPv6, query._user_defined_af)
+
+    def testInitializeAcceptsValidUserDefinedCityAndLatLon(self):
+        user_defined_city = 'user_defined_city'
+        user_defined_latitude = 0.0
+        user_defined_longitude = 4.3
+
+        self.mock_query_params[message.CITY] = user_defined_city
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        #TODO(mtlynch): We should revisit this because the combination of
+        # parameters here is confusing. What takes precedence if the city
+        # and the lat/lon are contradictory?
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertEqual(user_defined_city, query.city)
+        self.assertIsNone(query.country)
+        self.assertEqual(user_defined_latitude, query.latitude)
+        self.assertEqual(user_defined_longitude, query.longitude)
+
+    # TODO(mtlynch): These tests fail because LookupQuery actually doesn't
+    # handle these cases correctly. Uncomment when the code is fixed.
+    #def testInitializeIgnoresInvalidUserDefinedLatWithValidLon(self):
+    #    user_defined_latitude = 'invalid_latitude'
+    #    user_defined_longitude = 36.0
+
+    #    self.mock_query_params[message.LATITUDE] = user_defined_latitude
+    #    self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+    #    query = lookup_query.LookupQuery()
+    #    query.initialize_from_http_request(self.mock_request)
+
+    #    self.assertEqual(self.mock_gae_latitude, query.latitude)
+    #    self.assertEqual(self.mock_gae_longitude, query.longitude)
+    #    self.assertEqual(self.mock_gae_city, query.city)
+    #    self.assertEqual(self.mock_gae_country, query.country)
+
+    #def testInitializeIgnoresValidUserDefinedLatWithInvalidLon(self):
+    #    user_defined_latitude = 36.0
+    #    user_defined_longitude = 'invalid_longitude'
+
+    #    self.mock_query_params[message.LATITUDE] = user_defined_latitude
+    #    self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+    #    query = lookup_query.LookupQuery()
+    #    query.initialize_from_http_request(self.mock_request)
+
+    #    self.assertEqual(self.mock_gae_latitude, query.latitude)
+    #    self.assertEqual(self.mock_gae_longitude, query.longitude)
+    #    self.assertEqual(self.mock_gae_city, query.city)
+    #    self.assertEqual(self.mock_gae_country, query.country)
+
+    def testInitializeIgnoresInvalidUserDefinedLatLonEvenIfCityIsValid(self):
+        user_defined_latitude = 'invalid_latitude'
+        user_defined_longitude = 'invalid_longitude'
+        user_defined_city = 'valid_city'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+        self.mock_query_params[message.CITY] = user_defined_city
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        # Can't geolocate just a city, so use a random site.
+        self.assertEqual(message.POLICY_RANDOM, query.policy)
+        self.assertIsNone(query.latitude)
+        self.assertIsNone(query.longitude)
+        #TODO(mtlynch): This is confusing behavior. If we're going to use a
+        # random site, the city field should be None.
+        self.assertEqual(user_defined_city, query.city)
+        self.assertIsNone(query.country)
+
+    def testInitializeIgnoresInvalidUserDefinedLatLonEvenIfCountryIsValid(self):
+        user_defined_latitude = 'invalid_latitude'
+        user_defined_longitude = 'invalid_longitude'
+        user_defined_country = 'valid_country'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+        self.mock_query_params[message.COUNTRY] = user_defined_country
+
+        maxmind_latitude = 55.5
+        maxmind_longitude = 77.7
+
+        maxmind.get_country_geolocation.return_value = maxmind.GeoRecord(
+            latitude=maxmind_latitude, longitude=maxmind_longitude,
+            country=user_defined_country)
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        #TODO(mtlynch): This is confusing behavior. If the only valid user-
+        # defined field is the country name, the policy should implicitly be
+        # message.COUNTRY.
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertIsNone(query.latitude)
+        self.assertIsNone(query.longitude)
+        self.assertIsNone(query.city)
+        self.assertEqual(user_defined_country, query.country)
+
+    def testInitializeWithUserDefinedCountryGetsGeolocationForThatCountry(self):
+        user_defined_country = 'user_defined_country'
+        self.mock_query_params[message.COUNTRY] = user_defined_country
+
+        maxmind_city = None
+        maxmind_country = user_defined_country
+        maxmind_latitude = 55.5
+        maxmind_longitude = 77.7
+
+        maxmind.get_country_geolocation.return_value = maxmind.GeoRecord(
+            city=maxmind_city, country=maxmind_country,
+            latitude=maxmind_latitude, longitude=maxmind_longitude)
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(maxmind_latitude, query.latitude)
+        self.assertEqual(maxmind_longitude, query.longitude)
+        self.assertIsNone(query.city)
+        self.assertEqual(maxmind_country, query.country)
+
+    def testInitializeAcceptsUserDefinedLatLonAndCountry(self):
+        user_defined_latitude = 99.0
+        user_defined_longitude = 100.0
+        user_defined_country = 'user_defined_country'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+        self.mock_query_params[message.COUNTRY] = user_defined_country
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(user_defined_latitude, query.latitude)
+        self.assertEqual(user_defined_longitude, query.longitude)
+        self.assertIsNone(query.city)
+        self.assertEqual(user_defined_country, query.country)
+
+    def testInitializeAcceptsGeoPolicy(self):
+        self.mock_query_params[message.POLICY] = message.POLICY_GEO
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(message.POLICY_GEO, query.policy)
+
+    def testInitializeAcceptsCountryPolicy(self):
+        user_defined_country = 'user_defined_country'
+        self.mock_query_params[message.POLICY] = message.COUNTRY
+        self.mock_query_params[message.COUNTRY] = user_defined_country
+        maxmind.get_country_geolocation.return_value = maxmind.GeoRecord(
+            country=user_defined_country)
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(message.POLICY_COUNTRY, query.policy)
+        self.assertEqual(user_defined_country, query.country)
+
+    def testInitializeUsesMaxmindWhenUserDefinedIpv4Exists(self):
+        user_defined_ip = '5.6.7.8'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ip
+
+        maxmind_city = 'maxmind_city'
+        maxmind_country = 'maxmind_country'
+        maxmind_latitude = 55.5
+        maxmind_longitude = 77.7
+
+        maxmind.get_ip_geolocation.return_value = maxmind.GeoRecord(
+            city=maxmind_city, country=maxmind_country,
+            latitude=maxmind_latitude, longitude=maxmind_longitude)
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        # Make sure we looked up the user-defined IP, not the request IP.
+        maxmind.get_ip_geolocation.assert_called_with(user_defined_ip)
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertEqual(maxmind_city, query.city)
+        self.assertEqual(maxmind_country, query.country)
+        self.assertEqual(maxmind_latitude, query.latitude)
+        self.assertEqual(maxmind_longitude, query.longitude)
+
+    def testInitializeUsesMaxmindWhenUserDefinedIpv6Exists(self):
+        user_defined_ip = '1:2:3::4'
+        self.mock_query_params[message.REMOTE_ADDRESS] = user_defined_ip
+
+        maxmind_city = 'maxmind_city'
+        maxmind_country = 'maxmind_country'
+        maxmind_latitude = 55.5
+        maxmind_longitude = 77.7
+
+        maxmind.get_ip_geolocation.return_value = maxmind.GeoRecord(
+            city=maxmind_city, country=maxmind_country,
+            latitude=maxmind_latitude, longitude=maxmind_longitude)
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        # Make sure we looked up the user-defined IP, not the request IP.
+        maxmind.get_ip_geolocation.assert_called_with(user_defined_ip)
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertEqual(maxmind_city, query.city)
+        self.assertEqual(maxmind_country, query.country)
+        self.assertEqual(maxmind_latitude, query.latitude)
+        self.assertEqual(maxmind_longitude, query.longitude)
+
+    def testInitializeUsesMaxmindWhenAppEngineGeoDataIsMissing(self):
+        # Remove all mock AppEngine headers
+        self.mock_request.headers = {}
+
+        maxmind_city = 'maxmind_city'
+        maxmind_country = 'maxmind_country'
+        maxmind_latitude = 55.5
+        maxmind_longitude = 77.7
+
+        maxmind.get_ip_geolocation.return_value = maxmind.GeoRecord(
+            city=maxmind_city, country=maxmind_country,
+            latitude=maxmind_latitude, longitude=maxmind_longitude)
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertEqual(maxmind_city, query.city)
+        self.assertEqual(maxmind_country, query.country)
+        self.assertEqual(maxmind_latitude, query.latitude)
+        self.assertEqual(maxmind_longitude, query.longitude)
+
+    def testInitializeUsesRandomPolicyWhenAllGeoDataIsMissing(self):
+        """When no geo information is available, choose a random site."""
+        # Remove all mock AppEngine headers
+        self.mock_request.headers = {}
+
+        # Simulate Maxmind missing geo data for the request IP
+        maxmind.get_ip_geolocation.return_value = maxmind.GeoRecord()
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(message.POLICY_RANDOM, query.policy)
+
+    def testInitializeDefaultsToGeoPolicyWhenUserDefinedPolicyIsInvalidAndGeoDataIsAvailable(
+            self):
+        self.mock_query_params[message.POLICY] = 'invalid_policy'
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual(message.POLICY_GEO, query.policy)
+
+    def testInitializeAcceptsMetroOption(self):
+        self.mock_query_params[message.METRO] = 'lax'
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(message.POLICY_METRO, query.policy)
+        self.assertEqual('lax', query.metro)
 
 
 if __name__ == '__main__':
     unittest2.main()
+

--- a/server/mlabns/tests/test_lookup_query.py
+++ b/server/mlabns/tests/test_lookup_query.py
@@ -216,35 +216,35 @@ class LookupQueryTestCase(unittest2.TestCase):
 
     # TODO(mtlynch): These tests fail because LookupQuery actually doesn't
     # handle these cases correctly. Uncomment when the code is fixed.
-    #def testInitializeIgnoresInvalidUserDefinedLatWithValidLon(self):
-    #    user_defined_latitude = 'invalid_latitude'
-    #    user_defined_longitude = 36.0
+    """def testInitializeIgnoresInvalidUserDefinedLatWithValidLon(self):
+        user_defined_latitude = 'invalid_latitude'
+        user_defined_longitude = 36.0
 
-    #    self.mock_query_params[message.LATITUDE] = user_defined_latitude
-    #    self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
 
-    #    query = lookup_query.LookupQuery()
-    #    query.initialize_from_http_request(self.mock_request)
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
 
-    #    self.assertEqual(self.mock_gae_latitude, query.latitude)
-    #    self.assertEqual(self.mock_gae_longitude, query.longitude)
-    #    self.assertEqual(self.mock_gae_city, query.city)
-    #    self.assertEqual(self.mock_gae_country, query.country)
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
 
-    #def testInitializeIgnoresValidUserDefinedLatWithInvalidLon(self):
-    #    user_defined_latitude = 36.0
-    #    user_defined_longitude = 'invalid_longitude'
+    def testInitializeIgnoresValidUserDefinedLatWithInvalidLon(self):
+        user_defined_latitude = 36.0
+        user_defined_longitude = 'invalid_longitude'
 
-    #    self.mock_query_params[message.LATITUDE] = user_defined_latitude
-    #    self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
 
-    #    query = lookup_query.LookupQuery()
-    #    query.initialize_from_http_request(self.mock_request)
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
 
-    #    self.assertEqual(self.mock_gae_latitude, query.latitude)
-    #    self.assertEqual(self.mock_gae_longitude, query.longitude)
-    #    self.assertEqual(self.mock_gae_city, query.city)
-    #    self.assertEqual(self.mock_gae_country, query.country)
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)"""
 
     def testInitializeIgnoresInvalidUserDefinedLatLonEvenIfCityIsValid(self):
         user_defined_latitude = 'invalid_latitude'
@@ -270,17 +270,15 @@ class LookupQueryTestCase(unittest2.TestCase):
     def testInitializeIgnoresInvalidUserDefinedLatLonEvenIfCountryIsValid(self):
         user_defined_latitude = 'invalid_latitude'
         user_defined_longitude = 'invalid_longitude'
-        user_defined_country = 'valid_country'
+        user_defined_country = 'user_defined_country'
 
         self.mock_query_params[message.LATITUDE] = user_defined_latitude
         self.mock_query_params[message.LONGITUDE] = user_defined_longitude
         self.mock_query_params[message.COUNTRY] = user_defined_country
 
-        maxmind_latitude = 55.5
-        maxmind_longitude = 77.7
-
+        # LookupQuery confusingly ignores these values.
         maxmind.get_country_geolocation.return_value = maxmind.GeoRecord(
-            latitude=maxmind_latitude, longitude=maxmind_longitude,
+            latitude=55.7, longitude=77.7,
             country=user_defined_country)
 
         query = lookup_query.LookupQuery()
@@ -288,7 +286,9 @@ class LookupQueryTestCase(unittest2.TestCase):
 
         #TODO(mtlynch): This is confusing behavior. If the only valid user-
         # defined field is the country name, the policy should implicitly be
-        # message.COUNTRY.
+        # message.COUNTRY. Additionally, an invalid lat/lon should be treated
+        # the same as no lat/lon, but the current implementation changes invalid
+        # lat/lon to None values, but fills in missing lat/lon from Maxmind.
         self.assertEqual(message.POLICY_GEO, query.policy)
         self.assertIsNone(query.latitude)
         self.assertIsNone(query.longitude)

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -12,7 +12,7 @@ class LookupQuery:
         self.policy = None
         self.metro = None
         self.response_format = None
-        self.geolocation_type = None
+        self._geolocation_type = None
         self.ip_address = None
         self.address_family = None
         self.city = None
@@ -20,22 +20,22 @@ class LookupQuery:
         self.latitude = None
         self.longitude = None
         self.distance = None
-        self.gae_ip = None
-        self.user_defined_ip = None
-        self.gae_af = None
-        self.user_defined_af = None
-        self.user_defined_city = None
-        self.user_defined_country = None
-        self.user_defined_latitude = None
-        self.user_defined_longitude = None
-        self.gae_city = None
-        self.gae_country = None
-        self.gae_latitude = None
-        self.gae_longitude = None
-        self.maxmind_city = None
-        self.maxmind_country = None
-        self.maxmind_latitude = None
-        self.maxmind_longitude = None
+        self._gae_ip = None
+        self._user_defined_ip = None
+        self._gae_af = None
+        self._user_defined_af = None
+        self._user_defined_city = None
+        self._user_defined_country = None
+        self._user_defined_latitude = None
+        self._user_defined_longitude = None
+        self._gae_city = None
+        self._gae_country = None
+        self._gae_latitude = None
+        self._gae_longitude = None
+        self._maxmind_city = None
+        self._maxmind_country = None
+        self._maxmind_latitude = None
+        self._maxmind_longitude = None
 
     def initialize_from_http_request(self, request):
         """Initializes the lookup parameters from the HTTP request.
@@ -44,57 +44,54 @@ class LookupQuery:
             request: An instance of google.appengine.webapp.Request.
         """
         self.tool_id = request.path.strip('/').split('/')[0]
-        self.set_response_format(request)
-        self.set_ip_address_and_address_family(request)
-        self.set_geolocation(request)
+        self._set_response_format(request)
+        self._set_ip_address_and_address_family(request)
+        self._set_geolocation(request)
         self.metro = request.get(message.METRO, default_value=None)
-        self.set_policy(request)
+        self._set_policy(request)
 
-    def set_response_format(self, request):
-        self.response_format = request.get(message.RESPONSE_FORMAT,
-                                           default_value=None)
-        if self.response_format is None or \
-            self.response_format not in message.VALID_FORMATS:
+    def _set_response_format(self, request):
+        self.response_format = request.get(
+            message.RESPONSE_FORMAT,
+            default_value=message.DEFAULT_RESPONSE_FORMAT)
+        if self.response_format not in message.VALID_FORMATS:
             logging.warning('Non valid response format %s.',
                             self.response_format)
             self.response_format = message.DEFAULT_RESPONSE_FORMAT
 
-    def set_ip_address_and_address_family(self, request):
-        self.set_user_defined_ip_and_af(request)
-        self.set_gae_ip_and_af(request)
+    def _set_ip_address_and_address_family(self, request):
+        self._set_user_defined_ip_and_af(request)
+        self._set_gae_ip_and_af(request)
 
         # User-defined args have precedence over args provided by GAE.
-        if self.user_defined_ip is not None:
-            self.ip_address = self.user_defined_ip
-        elif self.gae_ip is not None:
-            self.ip_address = self.gae_ip
+        if self._user_defined_ip is not None:
+            self.ip_address = self._user_defined_ip
+        elif self._gae_ip is not None:
+            self.ip_address = self._gae_ip
 
-        if self.user_defined_af is not None:
-            self.address_family = self.user_defined_af
-        elif self.gae_af is not None:
-            self.address_family = self.gae_af
+        if self._user_defined_af is not None:
+            self.address_family = self._user_defined_af
+        elif self._gae_af is not None:
+            self.address_family = self._gae_af
 
-    def set_user_defined_ip_and_af(self, request):
-        self.user_defined_ip = request.get(message.REMOTE_ADDRESS,
-                                           default_value=None)
-        self.user_defined_af = request.get(message.ADDRESS_FAMILY,
-                                           default_value=None)
-        if self.user_defined_ip is not None:
-            self._set_ip_and_af('user_defined_ip', 'user_defined_af')
+    def _set_user_defined_ip_and_af(self, request):
+      self._user_defined_ip = request.get(message.REMOTE_ADDRESS,
+                                          default_value=None)
+      self._user_defined_af = request.get(message.ADDRESS_FAMILY,
+                                          default_value=None)
+      if self._user_defined_ip:
+          self._set_ip_and_af('_user_defined_ip', '_user_defined_af')
+      if not self._user_defined_ip and self._user_defined_af:
+          logging.warning(
+              ('User specified an address family, but did not specify a '
+               'valid IP. Ignoring address family: %s'),
+              self._user_defined_af)
+          self._user_defined_af = None
 
-        if self.user_defined_ip is None and self.user_defined_af is not None:
-            # Non valid user-defined IP or IP not user-defined.
-            # Verify user-defined address family.
-            if self.user_defined_af != message.ADDRESS_FAMILY_IPv4 \
-                and self.user_defined_af != message.ADDRESS_FAMILY_IPv6:
-                logging.warning('Non valid address family %s',
-                                self.user_defined_af)
-                self.user_defined_af = None
-
-    def set_gae_ip_and_af(self, request):
-        self.gae_ip = request.remote_addr
-        if self.gae_ip is not None:
-            self._set_ip_and_af('gae_ip', 'gae_af')
+    def _set_gae_ip_and_af(self, request):
+        self._gae_ip = request.remote_addr
+        if self._gae_ip is not None:
+            self._set_ip_and_af('_gae_ip', '_gae_af')
 
     def _set_ip_and_af(self, ip_field, af_field):
         try:
@@ -126,51 +123,52 @@ class LookupQuery:
         # Non (valid) user-defined IP address. Don't change address family.
         self.__dict__[ip_field] = None
 
-    def set_geolocation(self, request):
-        self.set_appengine_geolocation(request)
-        self.user_defined_city = request.get(message.CITY, default_value=None)
-        self.user_defined_country = request.get(message.COUNTRY,
+    def _set_geolocation(self, request):
+        self._set_appengine_geolocation(request)
+        self._user_defined_city = request.get(message.CITY, default_value=None)
+        self._user_defined_country = request.get(message.COUNTRY,
                                                 default_value=None)
         input_latitude = request.get(message.LATITUDE, default_value=None)
         input_longitude = request.get(message.LONGITUDE, default_value=None)
 
         if input_latitude is not None and input_longitude is not None:
-            self.geolocation_type = constants.GEOLOCATION_USER_DEFINED
+            self._geolocation_type = constants.GEOLOCATION_USER_DEFINED
             try:
-                self.user_defined_latitude = float(input_latitude)
-                self.user_defined_longitude = float(input_longitude)
+                self._user_defined_latitude = float(input_latitude)
+                self._user_defined_longitude = float(input_longitude)
             except ValueError:
                 logging.error('Non valid user-defined lat, long (%s, %s).',
                                input_latitude, input_longitude)
-        elif self.user_defined_ip is not None or \
-            self.user_defined_country is not None:
-            self.geolocation_type = constants.GEOLOCATION_MAXMIND
-            self.set_maxmind_geolocation(self.user_defined_ip,
-                                         self.user_defined_country,
-                                         self.user_defined_city)
-        elif self.gae_latitude is not None and self.gae_longitude is not None:
-            self.geolocation_type = constants.GEOLOCATION_APP_ENGINE
-        elif self.gae_ip is not None or self.gae_country is not None:
-            self.set_maxmind_geolocation(self.gae_ip, self.gae_country,
-                                         self.gae_city)
+        elif self._user_defined_ip is not None or \
+            self._user_defined_country is not None:
+            self._geolocation_type = constants.GEOLOCATION_MAXMIND
+            self._set_maxmind_geolocation(self._user_defined_ip,
+                                          self._user_defined_country,
+                                          self._user_defined_city)
+        elif self._gae_latitude is not None and self._gae_longitude is not None:
+            self._geolocation_type = constants.GEOLOCATION_APP_ENGINE
+        elif self._gae_ip is not None or self._gae_country is not None:
+            self._geolocation_type = constants.GEOLOCATION_MAXMIND
+            self._set_maxmind_geolocation(self._gae_ip, self._gae_country,
+                                          self._gae_city)
 
-        if self.geolocation_type == constants.GEOLOCATION_USER_DEFINED:
-            self.city = self.user_defined_city
-            self.country = self.user_defined_country
-            self.latitude = self.user_defined_latitude
-            self.longitude = self.user_defined_longitude
-        elif self.geolocation_type == constants.GEOLOCATION_MAXMIND:
-            self.city = self.maxmind_city
-            self.country = self.maxmind_country
-            self.latitude = self.maxmind_latitude
-            self.longitude = self.maxmind_longitude
-        elif self.geolocation_type == constants.GEOLOCATION_APP_ENGINE:
-            self.city = self.gae_city
-            self.country = self.gae_country
-            self.latitude = self.gae_latitude
-            self.longitude = self.gae_longitude
+        if self._geolocation_type == constants.GEOLOCATION_USER_DEFINED:
+            self.city = self._user_defined_city
+            self.country = self._user_defined_country
+            self.latitude = self._user_defined_latitude
+            self.longitude = self._user_defined_longitude
+        elif self._geolocation_type == constants.GEOLOCATION_MAXMIND:
+            self.city = self._maxmind_city
+            self.country = self._maxmind_country
+            self.latitude = self._maxmind_latitude
+            self.longitude = self._maxmind_longitude
+        elif self._geolocation_type == constants.GEOLOCATION_APP_ENGINE:
+            self.city = self._gae_city
+            self.country = self._gae_country
+            self.latitude = self._gae_latitude
+            self.longitude = self._gae_longitude
 
-    def set_maxmind_geolocation(self, ip_address, country, city):
+    def _set_maxmind_geolocation(self, ip_address, country, city):
         geo_record = maxmind.GeoRecord()
         if ip_address is not None:
             geo_record = maxmind.get_ip_geolocation(ip_address)
@@ -178,12 +176,12 @@ class LookupQuery:
             geo_record = maxmind.get_city_geolocation(city, country)
         elif country is not None:
             geo_record = maxmind.get_country_geolocation(country)
-        self.maxmind_city = geo_record.city
-        self.maxmind_country = geo_record.country
-        self.maxmind_latitude = geo_record.latitude
-        self.maxmind_longitude = geo_record.longitude
+        self._maxmind_city = geo_record.city
+        self._maxmind_country = geo_record.country
+        self._maxmind_latitude = geo_record.latitude
+        self._maxmind_longitude = geo_record.longitude
 
-    def set_appengine_geolocation(self, request):
+    def _set_appengine_geolocation(self, request):
         """Adds geolocation info using the data provided by AppEngine.
 
         If the geolocation info is not included in the headers, it will
@@ -193,39 +191,44 @@ class LookupQuery:
             request: A webapp.Request instance.
         """
         if message.HEADER_CITY in request.headers:
-            self.gae_city = request.headers[message.HEADER_CITY]
+            self._gae_city = request.headers[message.HEADER_CITY]
         if message.HEADER_COUNTRY in request.headers:
-            self.gae_country = request.headers[message.HEADER_COUNTRY]
+            self._gae_country = request.headers[message.HEADER_COUNTRY]
         if message.HEADER_LAT_LONG in request.headers:
             lat_long = request.headers[message.HEADER_LAT_LONG]
             try:
-                self.gae_latitude, self.gae_longitude = [
+                self._gae_latitude, self._gae_longitude = [
                     float(x) for x in lat_long.split(',')]
             except ValueError:
                 logging.error('GAE provided bad lat/long %s.', lat_long)
 
-    def set_policy(self, request):
+    def _set_policy(self, request):
         self.policy = request.get(message.POLICY, default_value=None)
-        if (self.user_defined_latitude is not None and \
-            self.user_defined_longitude is not None) or \
-            self.user_defined_ip is not None:
+        if (self._user_defined_latitude is not None and \
+            self._user_defined_longitude is not None) or \
+            self._user_defined_ip is not None:
             if self.policy != message.POLICY_GEO and \
                self.policy != message.POLICY_GEO_OPTIONS:
-                logging.warning(
-                    'Lat/longs user-defined, but policy is %s.', self.policy)
+                if self.policy:
+                     logging.warning(
+                         'Lat/longs user-defined, but policy is %s.',
+                         self.policy)
                 self.policy = message.POLICY_GEO
             return
-        if self.user_defined_country is not None:
+        if self._user_defined_country is not None:
             if self.policy != message.POLICY_COUNTRY and \
                 self.policy != message.POLICY_GEO:
-                logging.warning(
-                    'Country user-defined, but policy is %s.', self.policy)
+                if self.policy:
+                    logging.warning(
+                        'Country user-defined, but policy is %s.',
+                        self.policy)
                 self.policy = message.POLICY_GEO
             return
         if self.metro is not None:
             if self.policy != message.POLICY_METRO:
-                logging.warning(
-                     'Metro defined, but policy is %s', self.policy)
+                if self.policy:
+                    logging.warning(
+                         'Metro defined, but policy is %s', self.policy)
                 self.policy = message.POLICY_METRO
             return
         if self.policy == message.POLICY_GEO:
@@ -234,7 +237,7 @@ class LookupQuery:
                 self.policy = message.POLICY_RANDOM
             return
         if self.policy == message.POLICY_COUNTRY:
-            if self.user_defined_country is None:
+            if self._user_defined_country is None:
                 logging.warning('Policy country, but arg country not defined.')
                 self.policy = self._get_default_policy()
             return
@@ -249,7 +252,8 @@ class LookupQuery:
             return
         if self.policy == message.POLICY_ALL:
             return
-        logging.warning('Non valid policy %s.', self.policy)
+        if self.policy:
+            logging.warning('Non valid policy %s.', self.policy)
         self.policy = self._get_default_policy()
 
     def _get_default_policy(self):

--- a/server/mlabns/util/maxmind.py
+++ b/server/mlabns/util/maxmind.py
@@ -13,11 +13,11 @@ import string
 # http://www.maxmind.com/app/csv.
 
 class GeoRecord:
-    def __init__(self):
-        self.city = None
-        self.country = None
-        self.latitude = None
-        self.longitude = None
+    def __init__(self, city=None, country=None, latitude=None, longitude=None):
+        self.city = city
+        self.country = country
+        self.latitude = latitude
+        self.longitude = longitude
 
 
 def get_ip_geolocation(remote_addr):


### PR DESCRIPTION
This change refactors LookupQuery to make private the methods and
properties that are not referenced outside of the class itself (or the
test code). LookupQuery only needs to expose
initialize_from_http_request, so the rest of its methods are now
private.

This change includes a complete rewrite of test_lookup_query so that
it's only testing LookupQuery's public interface instead of its private
methods.

In the process of rewriting the test suite, I identified some bugs in
LookupQuery and also reduced some of the logging messages, because it
was firing warnings when optional fields were not set (the warnings
should only fire for non-optional fields or when an invalid option is
specified). I fixed a couple small bugs in this CL, but I left a few
TODOs in the test code for additional fixes I plan to make in a
subsequent CL.
