### PR TITLE
Fixes LookupQuery's handling of address family parameter

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -347,14 +347,11 @@ class LookupHandler(webapp.RequestHandler):
         # included in the request_log object.
         logging.info(
             '[lookup]'
-            '%s,%s,%s,%s,%s,%s,%s,'
+            '%s,%s,%s,%s,'
             '%s,'
             '%s,%s,%s,%s,%s,%s,%s',
             # Info about the user:
-            query._user_defined_ip,
-            query.user_defined_af,
-            query._gae_ip,
-            query._gae_af,
+            query.tool_address_family,
             query.ip_address,
             query.address_family,
             user_agent,

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -5,6 +5,30 @@ from mlabns.util import maxmind
 
 import logging
 
+def _is_valid_ip(ip):
+    """Indicates whether this is a valid IP string.
+
+    Args:
+      ip: A string containing an IP address in IPv4 or IPv6 format.
+
+    Returns:
+      True if the IP address is a well-formed and legal IP address.
+    """
+    return _is_valid_ipv4(ip) or _is_valid_ipv6(ip)
+
+def _is_valid_ipv4(ip):
+    try:
+        ipaddr.IPv4Address(ip)
+        return True
+    except ipaddr.AddressValueError:
+        return False
+
+def _is_valid_ipv6(ip):
+    try:
+        ipaddr.IPv6Address(ip)
+        return True
+    except ipaddr.AddressValueError:
+        return False
 
 class LookupQuery:
     def __init__(self):
@@ -14,19 +38,13 @@ class LookupQuery:
         self.response_format = None
         self._geolocation_type = None
         self.ip_address = None
-        self.address_family = None
+        self.tool_address_family = None
         self.city = None
         self.country = None
         self.latitude = None
         self.longitude = None
         self.distance = None
-        self._gae_ip = None
-        self._user_defined_ip = None
-        self._gae_af = None
-        #TODO(mtlynch): Rename user_defined_af as it refers to the AF of the
-        # M-Lab tool to look for rather than the AF of the user that made the
-        # request (whereas user_defined_ip refers to the client).
-        self.user_defined_af = None
+        self._ip_is_explicit = False
         self._user_defined_city = None
         #TODO(mtlynch): We are using two country fields to store the same type
         # of information, but using user_defined_country in some cases and
@@ -51,7 +69,8 @@ class LookupQuery:
         """
         self.tool_id = request.path.strip('/').split('/')[0]
         self._set_response_format(request)
-        self._set_ip_address_and_address_family(request)
+        self._set_ip_address(request)
+        self._set_tool_address_family(request)
         self._set_geolocation(request)
         self.metro = request.get(message.METRO, default_value=None)
         self._set_policy(request)
@@ -65,79 +84,24 @@ class LookupQuery:
                             self.response_format)
             self.response_format = message.DEFAULT_RESPONSE_FORMAT
 
-    def _set_ip_address_and_address_family(self, request):
-        self._set_gae_ip_and_af(request)
-        self._set_user_defined_ip_and_af(request)
+    def _set_ip_address(self, request):
+        user_defined_ip = request.get(message.REMOTE_ADDRESS)
 
-        # User-defined args have precedence over args provided by GAE.
-        if self._user_defined_ip is not None:
-            self.ip_address = self._user_defined_ip
-        elif self._gae_ip is not None:
-            self.ip_address = self._gae_ip
+        # User-defined IP overrides the request source IP
+        if (_is_valid_ip(user_defined_ip) and
+                user_defined_ip != request.remote_addr):
+            self.ip_address = user_defined_ip
+            self._ip_is_explicit = True
+        else:
+            self.ip_address = request.remote_addr
+            self._ip_is_explicit = False
 
-        if self.user_defined_af is not None:
-            self.address_family = self.user_defined_af
-        elif self._gae_af is not None:
-            self.address_family = self._gae_af
-
-    def _set_user_defined_ip_and_af(self, request):
-      self._user_defined_ip = request.get(message.REMOTE_ADDRESS,
-                                          default_value=None)
-      self.user_defined_af = request.get(message.ADDRESS_FAMILY,
-                                         default_value=None)
-      # If the user-defined IP address matches the GAE IP address (i.e. the user
-      # is just explicitly stating their own IP address in the request), then
-      # treat it as if the user did not explicitly define an IP.
-      if self._user_defined_ip == self._gae_ip:
-          self._user_defined_ip = None
-          return
-      if self._user_defined_ip:
-          self._set_ip_and_af('_user_defined_ip', 'user_defined_af')
-      if not self._user_defined_ip and self.user_defined_af:
-          logging.warning(
-              ('User specified an address family, but did not specify a '
-               'valid IP. Ignoring address family: %s'),
-              self.user_defined_af)
-          self.user_defined_af = None
-
-    def _set_gae_ip_and_af(self, request):
-        self._gae_ip = request.remote_addr
-        if self._gae_ip is not None:
-            self._set_ip_and_af('_gae_ip', '_gae_af')
-
-    def _set_ip_and_af(self, ip_field, af_field):
-        try:
-            ipaddr.IPv4Address(self.__dict__[ip_field])
-            if self.__dict__[af_field] is not None and \
-                self.__dict__[af_field] != message.ADDRESS_FAMILY_IPv4:
-                logging.warning(
-                    'IP address is IPv4, but address family is %s.',
-                    self.__dict__[af_field])
-                # The IP address has precedence over the address family.
-                # TODO(mtlynch): LookupQuery handles the user-defined AF
-                # incorrectly. The AF field refers to the tool, not the client.
-                # An IPv4 client can legally request information about an IPv6
-                # tool.
-            self.__dict__[af_field] = message.ADDRESS_FAMILY_IPv4
-            return
-        except ipaddr.AddressValueError:
-            pass
-
-        try:
-            ipaddr.IPv6Address(self.__dict__[ip_field])
-            if self.__dict__[af_field] is not None and \
-                self.__dict__[af_field] != message.ADDRESS_FAMILY_IPv6:
-                logging.warning(
-                    'IP address is IPv6, but address family is %s.',
-                    self.__dict__[af_field])
-                # The IP address has precedence over the address family.
-            self.__dict__[af_field] = message.ADDRESS_FAMILY_IPv6
-            return
-        except ipaddr.AddressValueError:
-            pass
-
-        # Non (valid) user-defined IP address. Don't change address family.
-        self.__dict__[ip_field] = None
+    def _set_tool_address_family(self, request):
+        tool_address_family = request.get(message.ADDRESS_FAMILY)
+        valid_address_families = (message.ADDRESS_FAMILY_IPv4,
+                                  message.ADDRESS_FAMILY_IPv6)
+        if tool_address_family in valid_address_families:
+          self.tool_address_family = tool_address_family
 
     def _set_geolocation(self, request):
         self._set_appengine_geolocation(request)
@@ -155,17 +119,20 @@ class LookupQuery:
             except ValueError:
                 logging.error('Non valid user-defined lat, long (%s, %s).',
                                input_latitude, input_longitude)
-        elif self._user_defined_ip is not None or \
-            self.user_defined_country is not None:
+        elif self._ip_is_explicit or self.user_defined_country:
+            if self._ip_is_explicit:
+              ip_address_to_geolocate = self.ip_address
+            else:
+              ip_address_to_geolocate = None
             self._geolocation_type = constants.GEOLOCATION_MAXMIND
-            self._set_maxmind_geolocation(self._user_defined_ip,
+            self._set_maxmind_geolocation(ip_address_to_geolocate,
                                           self.user_defined_country,
                                           self._user_defined_city)
-        elif self._gae_latitude is not None and self._gae_longitude is not None:
+        elif self._gae_latitude and self._gae_longitude:
             self._geolocation_type = constants.GEOLOCATION_APP_ENGINE
-        elif self._gae_ip is not None or self._gae_country is not None:
+        else:
             self._geolocation_type = constants.GEOLOCATION_MAXMIND
-            self._set_maxmind_geolocation(self._gae_ip, self._gae_country,
+            self._set_maxmind_geolocation(self.ip_address, self._gae_country,
                                           self._gae_city)
 
         if self._geolocation_type == constants.GEOLOCATION_USER_DEFINED:
@@ -220,9 +187,9 @@ class LookupQuery:
 
     def _set_policy(self, request):
         self.policy = request.get(message.POLICY, default_value=None)
-        if (self._user_defined_latitude is not None and \
-            self._user_defined_longitude is not None) or \
-            self._user_defined_ip is not None:
+        if ((self._user_defined_latitude and
+             self._user_defined_longitude) or
+                self._ip_is_explicit):
             if self.policy != message.POLICY_GEO and \
                self.policy != message.POLICY_GEO_OPTIONS:
                 if self.policy:


### PR DESCRIPTION
LookupQuery was incorrectly handling the address_family query parameter.
The spec states:

```
When the user specifies an address_family=ipvX, only sliver tools that
have status_ipvX='online' will be considered in the server selection. If
there is no sliver tool in the requested address family, an error (not
found) is returned.
```

LookupQuery was treating the address_family field as a property of the
client and auto-populating it based on whether the user was on IPv4 or
IPv6.

This change modifies LookupQuery to treat the ip and address_family
fields as independent. It also simplifies IP address handling in the
class and eliminates unnecessary class properties.
