### PR TITLE
Fixes LookupQuery's lat/lon behavior

### DIFF
--- a/server/mlabns/tests/test_lookup_query.py
+++ b/server/mlabns/tests/test_lookup_query.py
@@ -11,7 +11,7 @@ from mlabns.util import message
 
 class LookupQueryTestCase(unittest2.TestCase):
 
-    def mock_get(self, arg, default_value):
+    def mock_get(self, arg, default_value=None):
         """Mock method to replace the GAE get() API for web requests."""
         if arg in self.mock_query_params:
             return self.mock_query_params[arg]
@@ -195,8 +195,8 @@ class LookupQueryTestCase(unittest2.TestCase):
 
     def testInitializeAcceptsValidUserDefinedCityAndLatLon(self):
         user_defined_city = 'user_defined_city'
-        user_defined_latitude = 0.0
-        user_defined_longitude = 4.3
+        user_defined_latitude = '0.0'
+        user_defined_longitude = '4.3'
 
         self.mock_query_params[message.CITY] = user_defined_city
         self.mock_query_params[message.LATITUDE] = user_defined_latitude
@@ -211,14 +211,77 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertEqual(message.POLICY_GEO, query.policy)
         self.assertEqual(user_defined_city, query.city)
         self.assertIsNone(query.country)
-        self.assertEqual(user_defined_latitude, query.latitude)
-        self.assertEqual(user_defined_longitude, query.longitude)
+        self.assertEqual(float(user_defined_latitude), query.latitude)
+        self.assertEqual(float(user_defined_longitude), query.longitude)
 
-    # TODO(mtlynch): These tests fail because LookupQuery actually doesn't
-    # handle these cases correctly. Uncomment when the code is fixed.
-    """def testInitializeIgnoresInvalidUserDefinedLatWithValidLon(self):
+    def testInitializeIgnoresInvalidUserDefinedLatWithValidLon(self):
+        """If lat is invalid, but lon is valid, ignore both."""
         user_defined_latitude = 'invalid_latitude'
-        user_defined_longitude = 36.0
+        user_defined_longitude = '36.0'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
+
+    def testInitializeIgnoresTooNegativeLatitude(self):
+        """Ignore a latitude that's below the -90 -> +90 valid range."""
+        user_defined_latitude = '-90.1'
+        user_defined_longitude = '100.2'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
+
+    def testInitializeIgnoresTooPositiveLatitude(self):
+        """Ignore a latitude that's above the -90 -> +90 valid range."""
+        user_defined_latitude = '90.1'
+        user_defined_longitude = '36.0'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
+
+    def testInitializeIgnoresTooNegativeLongitude(self):
+        """Ignore a longitude that's below the -180 -> +180 valid range."""
+        user_defined_latitude = '15.5'
+        user_defined_longitude = '-180.01'
+
+        self.mock_query_params[message.LATITUDE] = user_defined_latitude
+        self.mock_query_params[message.LONGITUDE] = user_defined_longitude
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
+
+    def testInitializeIgnoresTooPositiveLongitude(self):
+        """Ignore a longitude that's above the -180 -> +180 valid range."""
+        user_defined_latitude = '15.5'
+        user_defined_longitude = '180.1'
 
         self.mock_query_params[message.LATITUDE] = user_defined_latitude
         self.mock_query_params[message.LONGITUDE] = user_defined_longitude
@@ -232,7 +295,8 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertEqual(self.mock_gae_country, query.country)
 
     def testInitializeIgnoresValidUserDefinedLatWithInvalidLon(self):
-        user_defined_latitude = 36.0
+        """If lat is valid, but lon is invalid, ignore both."""
+        user_defined_latitude = '36.0'
         user_defined_longitude = 'invalid_longitude'
 
         self.mock_query_params[message.LATITUDE] = user_defined_latitude
@@ -244,7 +308,7 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertEqual(self.mock_gae_latitude, query.latitude)
         self.assertEqual(self.mock_gae_longitude, query.longitude)
         self.assertEqual(self.mock_gae_city, query.city)
-        self.assertEqual(self.mock_gae_country, query.country)"""
+        self.assertEqual(self.mock_gae_country, query.country)
 
     def testInitializeIgnoresInvalidUserDefinedLatLonEvenIfCityIsValid(self):
         user_defined_latitude = 'invalid_latitude'
@@ -258,14 +322,13 @@ class LookupQueryTestCase(unittest2.TestCase):
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.mock_request)
 
-        # Can't geolocate just a city, so use a random site.
-        self.assertEqual(message.POLICY_RANDOM, query.policy)
-        self.assertIsNone(query.latitude)
-        self.assertIsNone(query.longitude)
-        #TODO(mtlynch): This is confusing behavior. If we're going to use a
-        # random site, the city field should be None.
-        self.assertEqual(user_defined_city, query.city)
-        self.assertIsNone(query.country)
+        # Lat/lon is invalid, user-defined city is ignored if there's no
+        # country to go with it. Treat this as if the request specified nothing.
+        self.assertEqual(message.POLICY_GEO, query.policy)
+        self.assertEqual(self.mock_gae_city, query.city)
+        self.assertEqual(self.mock_gae_country, query.country)
+        self.assertEqual(self.mock_gae_latitude, query.latitude)
+        self.assertEqual(self.mock_gae_longitude, query.longitude)
 
     def testInitializeIgnoresInvalidUserDefinedLatLonEvenIfCountryIsValid(self):
         user_defined_latitude = 'invalid_latitude'
@@ -276,9 +339,10 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.mock_query_params[message.LONGITUDE] = user_defined_longitude
         self.mock_query_params[message.COUNTRY] = user_defined_country
 
-        # LookupQuery confusingly ignores these values.
+        maxmind_latitude = 55.5
+        maxmind_longitude = 77.7
         maxmind.get_country_geolocation.return_value = maxmind.GeoRecord(
-            latitude=55.7, longitude=77.7,
+            latitude=maxmind_latitude, longitude=maxmind_longitude,
             country=user_defined_country)
 
         query = lookup_query.LookupQuery()
@@ -286,12 +350,10 @@ class LookupQueryTestCase(unittest2.TestCase):
 
         #TODO(mtlynch): This is confusing behavior. If the only valid user-
         # defined field is the country name, the policy should implicitly be
-        # message.COUNTRY. Additionally, an invalid lat/lon should be treated
-        # the same as no lat/lon, but the current implementation changes invalid
-        # lat/lon to None values, but fills in missing lat/lon from Maxmind.
+        # message.COUNTRY.
         self.assertEqual(message.POLICY_GEO, query.policy)
-        self.assertIsNone(query.latitude)
-        self.assertIsNone(query.longitude)
+        self.assertEqual(maxmind_latitude, query.latitude)
+        self.assertEqual(maxmind_longitude, query.longitude)
         self.assertIsNone(query.city)
         self.assertEqual(user_defined_country, query.country)
 
@@ -318,8 +380,8 @@ class LookupQueryTestCase(unittest2.TestCase):
         self.assertEqual(user_defined_country, query.user_defined_country)
 
     def testInitializeAcceptsUserDefinedLatLonAndCountry(self):
-        user_defined_latitude = 99.0
-        user_defined_longitude = 100.0
+        user_defined_latitude = '89.0'
+        user_defined_longitude = '100.0'
         user_defined_country = 'user_defined_country'
 
         self.mock_query_params[message.LATITUDE] = user_defined_latitude
@@ -329,8 +391,8 @@ class LookupQueryTestCase(unittest2.TestCase):
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.mock_request)
 
-        self.assertEqual(user_defined_latitude, query.latitude)
-        self.assertEqual(user_defined_longitude, query.longitude)
+        self.assertEqual(float(user_defined_latitude), query.latitude)
+        self.assertEqual(float(user_defined_longitude), query.longitude)
         self.assertIsNone(query.city)
         self.assertEqual(user_defined_country, query.country)
         self.assertEqual(user_defined_country, query.user_defined_country)

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -190,7 +190,8 @@ class LookupQuery:
             request: A webapp.Request instance.
 
         Returns:
-            (lat, lon) as a 2-tuple if the user provided valid values for both.
+            (lat, lon) as a 2-tuple of floats if the user provided valid values
+            for both latitude and longitude.
             (None, None) if the values were not present or not valid.
         """
         MAX_LATITUDE_ABSOLUTE = 90.0

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -141,20 +141,15 @@ class LookupQuery:
 
     def _set_geolocation(self, request):
         self._set_appengine_geolocation(request)
-        self._user_defined_city = request.get(message.CITY, default_value=None)
-        self.user_defined_country = request.get(message.COUNTRY,
-                                                default_value=None)
-        input_latitude = request.get(message.LATITUDE, default_value=None)
-        input_longitude = request.get(message.LONGITUDE, default_value=None)
+        self._user_defined_city = request.get(message.CITY)
+        self.user_defined_country = request.get(message.COUNTRY)
+        input_latitude, input_longitude = self._get_user_defined_lat_lon(
+            request)
 
-        if input_latitude is not None and input_longitude is not None:
+        if (input_latitude is not None) and (input_longitude is not None):
             self._geolocation_type = constants.GEOLOCATION_USER_DEFINED
-            try:
-                self._user_defined_latitude = float(input_latitude)
-                self._user_defined_longitude = float(input_longitude)
-            except ValueError:
-                logging.error('Non valid user-defined lat, long (%s, %s).',
-                               input_latitude, input_longitude)
+            self._user_defined_latitude = input_latitude
+            self._user_defined_longitude = input_longitude
         elif self._user_defined_ip is not None or \
             self.user_defined_country is not None:
             self._geolocation_type = constants.GEOLOCATION_MAXMIND
@@ -183,6 +178,44 @@ class LookupQuery:
             self.country = self._gae_country
             self.latitude = self._gae_latitude
             self.longitude = self._gae_longitude
+
+    def _get_user_defined_lat_lon(self, request):
+        """Retrieves and validates the user-defined lat/lon from the request.
+
+        Retrieves the lat/lon fields from the query string of the request and
+        validates that the values are in the correct format and in the legal
+        range.
+
+        Args:
+            request: A webapp.Request instance.
+
+        Returns:
+            (lat, lon) as a 2-tuple if the user provided valid values for both.
+            (None, None) if the values were not present or not valid.
+        """
+        MAX_LATITUDE_ABSOLUTE = 90.0
+        MAX_LONGITUDE_ABSOLUTE = 180.0
+        input_latitude = request.get(message.LATITUDE)
+        input_longitude = request.get(message.LONGITUDE)
+
+        if not input_latitude or not input_longitude:
+            return None, None
+
+        try:
+            latitude = float(input_latitude)
+            longitude = float(input_longitude)
+        except ValueError:
+            logging.error('Invalid user-defined lat, long (%s, %s).',
+                           input_latitude, input_longitude)
+            return None, None
+
+        if ((abs(latitude) > MAX_LATITUDE_ABSOLUTE) or
+                (abs(longitude) > MAX_LONGITUDE_ABSOLUTE)):
+            logging.error('Lat/long out of range (%f, %f).',
+                           latitude, longitude)
+            return None, None
+
+        return latitude, longitude
 
     def _set_maxmind_geolocation(self, ip_address, country, city):
         geo_record = maxmind.GeoRecord()


### PR DESCRIPTION
Previously LookupQuery behaved unexpectedly if the user defined a valid
latitude value, but an invalid longitude value (or vice versa).

This change makes LookupQuery ignore both fields if it does not receive
valid values for both of them.
